### PR TITLE
Rework the repo structure to support local development and cloud builders.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,256 @@
 /.cookie
+
+# Created by https://www.toptal.com/developers/gitignore/api/go,intellij+all,windows,linux,macos,sublimetext,lua
+# Edit at https://www.toptal.com/developers/gitignore?templates=go,intellij+all,windows,linux,macos,sublimetext,lua
+
+### Go ###
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+### Go Patch ###
+/vendor/
+/Godeps/
+
+### Intellij+all ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### Intellij+all Patch ###
+# Ignores the whole .idea folder and all .iml files
+# See https://github.com/joeblau/gitignore.io/issues/186 and https://github.com/joeblau/gitignore.io/issues/360
+
+.idea/
+
+# Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-249601023
+
+*.iml
+modules.xml
+.idea/misc.xml
+*.ipr
+
+# Sonarlint plugin
+.idea/sonarlint
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### Lua ###
+# Compiled Lua sources
+luac.out
+
+# luarocks build files
+*.src.rock
+*.zip
+*.tar.gz
+
+# Object files
+*.o
+*.os
+*.ko
+*.obj
+*.elf
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+*.def
+*.exp
+
+# Shared objects (inc. Windows DLLs)
+*.so.*
+
+# Executables
+*.app
+*.i*86
+*.x86_64
+*.hex
+
+
+### macOS ###
+# General
 .DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### SublimeText ###
+# Cache files for Sublime Text
+*.tmlanguage.cache
+*.tmPreferences.cache
+*.stTheme.cache
+
+# Workspace files are user-specific
+*.sublime-workspace
+
+# Project files should be checked into the repository, unless a significant
+# proportion of contributors will probably not be using Sublime Text
+# *.sublime-project
+
+# SFTP configuration file
+sftp-config.json
+
+# Package control specific files
+Package Control.last-run
+Package Control.ca-list
+Package Control.ca-bundle
+Package Control.system-ca-bundle
+Package Control.cache/
+Package Control.ca-certs/
+Package Control.merged-ca-bundle
+Package Control.user-ca-bundle
+oscrypto-ca-bundle.crt
+bh_unicode_properties.cache
+
+# Sublime-github package stores a github token in this file
+# https://packagecontrol.io/packages/sublime-github
+GitHub.sublime-settings
+
+### Windows ###
+# Windows thumbnail cache files
 Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# End of https://www.toptal.com/developers/gitignore/api/go,intellij+all,windows,linux,macos,sublimetext,lua

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Defold
+Copyright (c) 2021 Defold Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
-# XOXO Nakama Server
+XOXO Nakama Server
+==================
+
 This repository contains the server logic for a Tic Tac Toe game running on [Nakama](https://heroiclabs.com/nakama-opensource/). The server handles matchmaking and turn based matches. 
 
 ## Game client
+
 A matching game client [made with Defold can be found here](https://github.com/defold/game-xoxo-nakama-client).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,9 @@
 version: '3'
 services:
   cockroachdb:
-    container_name: cockroachdb
-    image: cockroachdb/cockroach:v19.2.5
-    command: start --insecure --store=attrs=ssd,path=/var/lib/cockroach/
-    restart: always
+    image: cockroachdb/cockroach:latest-v20.2
+    command: start-single-node --insecure --store=attrs=ssd,path=/var/lib/cockroach/
+    restart: "no"
     volumes:
       - data:/var/lib/cockroach
     expose:
@@ -15,20 +14,20 @@ services:
       - "8080:8080"
   nakama:
     container_name: nakama
-    image: heroiclabs/nakama:2.12.0
+    image: heroiclabs/nakama:3.1.1
     entrypoint:
       - "/bin/sh"
       - "-ecx"
       - >
           /nakama/nakama migrate up --database.address root@cockroachdb:26257 &&
-          exec /nakama/nakama --name nakama1 --database.address root@cockroachdb:26257
+          exec /nakama/nakama --name nakama1 --database.address root@cockroachdb:26257 --runtime.path /nakama/data/modules
     restart: always
     links:
       - "cockroachdb:db"
     depends_on:
       - cockroachdb
     volumes:
-      - ./:/nakama/data
+      - ./:/nakama/data/modules
     expose:
       - "7349"
       - "7350"

--- a/main.lua
+++ b/main.lua
@@ -1,5 +1,5 @@
 --[[
-  Copyright 2020 The Nakama Authors
+  Copyright 2020 The Defold Foundation Authors & Contributors
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ end
 -- return match id
 local function makematch(context, matched_users)
     log("Creating TicTacToe match")
+
     -- print matched users
     for _, user in ipairs(matched_users) do
         local presence = user.presence
@@ -34,12 +35,12 @@ local function makematch(context, matched_users)
     local modulename = "tictactoe_match"
     local setupstate = { invited = matched_users }
     local matchid = nk.match_create(modulename, setupstate)
+
     return matchid
 end
 
-
 nk.run_once(function(ctx)
-  local now = os.time()
-  log("Backend loaded at %d", now)
-  nk.register_matchmaker_matched(makematch)
+    local now = os.time()
+    log("Backend loaded at %d", now)
+    nk.register_matchmaker_matched(makematch)
 end)

--- a/tictactoe_match.lua
+++ b/tictactoe_match.lua
@@ -1,3 +1,19 @@
+--[[
+  Copyright 2020 The Defold Foundation Authors & Contributors
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+]]--
+
 local tictactoe = require("tictactoe_state")
 local nk = require("nakama")
 

--- a/tictactoe_state.lua
+++ b/tictactoe_state.lua
@@ -1,3 +1,19 @@
+--[[
+  Copyright 2020 The Defold Foundation Authors & Contributors
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+]]--
+
 local M = {}
 
 local function index_to_row_column(index)
@@ -37,7 +53,6 @@ local function check_winner(state)
 	local won = match_row or match_column or match_cross
 	return won
 end
-
 
 local function check_draw(state)
 	local cells = state.cells
@@ -127,6 +142,5 @@ function M.dump(state)
 		print(("[%02d][%02d][%02d]"):format(c1, c2, c3))
 	end
 end
-
 
 return M


### PR DESCRIPTION
- Update ignore file with gitignore.io.
- Update Docker compose file to use Nakama 3.1.1 release and CRDB 20.2 release. Used with local development.
- Flattened the server code to be at the repo root and updated the path its accessed on with local development to keep the behaviour the same. This makes path lookups compatible with local development and the cloud builder.

The repo seems to be licensed under MIT but the code headers in the `main.lua` were Apache-2 Licensed. I think this should be standardized on one or the other. I'm happy to assign copyright on these changes under whichever license of course.

Hope this helps.
